### PR TITLE
빌드 트러블슈팅 가이드 추가 및 SessionCast stub 내장

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,45 @@ autofix-agent/
 
 ---
 
+## 트러블슈팅
+
+### Gradle 빌드 시 `Unsupported class file major version` 에러
+
+```
+BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_'
+Unsupported class file major version 69
+```
+
+Gradle 8.7은 Java 22까지만 지원합니다. Java 23 이상(major version 67+)을 사용 중이면 Java 17로 지정하여 빌드하세요:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew bootJar
+```
+
+설치된 Java 버전 확인:
+
+```bash
+/usr/libexec/java_home -V   # macOS
+```
+
+### `sessioncast-spring-boot-starter` 의존성을 찾을 수 없음
+
+```
+Could not find io.sessioncast:sessioncast-spring-boot-starter:1.0.0-SNAPSHOT
+```
+
+이 라이브러리는 공개 Maven 저장소에 배포되어 있지 않습니다. 프로젝트 내에 stub 클래스가 포함되어 있으므로 `build.gradle`에서 해당 의존성이 제거된 상태인지 확인하세요. SessionCast 없이도 규칙 기반 폴백 분석으로 정상 동작합니다.
+
+### WhaTap API 401 Unauthorized
+
+```
+401 Unauthorized from GET https://api.whatap.io/open/api/json/spot
+```
+
+환경변수 `WHATAP_API_TOKEN`과 `WHATAP_PCODE`가 올바르게 설정되었는지 확인하세요. 앱 기동 후 웹 UI(http://localhost:8095)에서 WhaTap 계정으로 로그인하면 자동으로 토큰이 갱신됩니다.
+
+---
+
 ## 라이선스
 
 MIT License

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
-    // SessionCast Spring Boot Starter — 자동 SessionCastClient 설정 + LLM Chat API
-    implementation 'io.sessioncast:sessioncast-spring-boot-starter:1.0.0-SNAPSHOT'
-
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/io/sessioncast/autofix/AutofixApplication.java
+++ b/src/main/java/io/sessioncast/autofix/AutofixApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "io.sessioncast")
 @EnableScheduling
 public class AutofixApplication {
     public static void main(String[] args) {

--- a/src/main/java/io/sessioncast/core/SessionCastClient.java
+++ b/src/main/java/io/sessioncast/core/SessionCastClient.java
@@ -1,0 +1,45 @@
+package io.sessioncast.core;
+
+import io.sessioncast.core.api.Capability;
+import io.sessioncast.core.api.LlmChatRequest;
+import io.sessioncast.core.api.LlmChatResponse;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+public class SessionCastClient {
+    private final String relay;
+    private final String token;
+    private volatile boolean connected = false;
+
+    private SessionCastClient(Builder builder) {
+        this.relay = builder.relay;
+        this.token = builder.token;
+    }
+
+    public boolean isConnected() { return connected; }
+
+    public CompletableFuture<LlmChatResponse> llmChat(LlmChatRequest request) {
+        return CompletableFuture.completedFuture(
+                new LlmChatResponse(null, new LlmChatResponse.LlmError("SessionCast stub - not connected")));
+    }
+
+    public static Builder builder() { return new Builder(); }
+
+    public static class Builder {
+        private String relay;
+        private String token;
+
+        public Builder relay(String relay) { this.relay = relay; return this; }
+        public Builder token(String token) { this.token = token; return this; }
+        public Builder machineId(String machineId) { return this; }
+        public Builder label(String label) { return this; }
+        public Builder reconnect(boolean enabled) { return this; }
+        public Builder reconnectDelay(Duration initial, Duration max) { return this; }
+        public Builder maxReconnectAttempts(int max) { return this; }
+        public Builder apiTimeout(Duration timeout) { return this; }
+        public Builder llmTimeout(Duration timeout) { return this; }
+        public Builder requiredCapabilities(Capability... caps) { return this; }
+        public SessionCastClient build() { return new SessionCastClient(this); }
+    }
+}

--- a/src/main/java/io/sessioncast/core/api/Capability.java
+++ b/src/main/java/io/sessioncast/core/api/Capability.java
@@ -1,0 +1,5 @@
+package io.sessioncast.core.api;
+
+public enum Capability {
+    LLM_CHAT
+}

--- a/src/main/java/io/sessioncast/core/api/LlmChatRequest.java
+++ b/src/main/java/io/sessioncast/core/api/LlmChatRequest.java
@@ -1,0 +1,30 @@
+package io.sessioncast.core.api;
+
+public class LlmChatRequest {
+    private final String system;
+    private final String user;
+    private final String model;
+
+    private LlmChatRequest(Builder builder) {
+        this.system = builder.system;
+        this.user = builder.user;
+        this.model = builder.model;
+    }
+
+    public String getSystem() { return system; }
+    public String getUser() { return user; }
+    public String getModel() { return model; }
+
+    public static Builder builder() { return new Builder(); }
+
+    public static class Builder {
+        private String system;
+        private String user;
+        private String model;
+
+        public Builder system(String system) { this.system = system; return this; }
+        public Builder user(String user) { this.user = user; return this; }
+        public Builder model(String model) { this.model = model; return this; }
+        public LlmChatRequest build() { return new LlmChatRequest(this); }
+    }
+}

--- a/src/main/java/io/sessioncast/core/api/LlmChatResponse.java
+++ b/src/main/java/io/sessioncast/core/api/LlmChatResponse.java
@@ -1,0 +1,17 @@
+package io.sessioncast.core.api;
+
+public class LlmChatResponse {
+    private final String content;
+    private final LlmError error;
+
+    public LlmChatResponse(String content, LlmError error) {
+        this.content = content;
+        this.error = error;
+    }
+
+    public String content() { return content; }
+    public boolean hasError() { return error != null; }
+    public LlmError error() { return error; }
+
+    public record LlmError(String message) {}
+}

--- a/src/main/java/io/sessioncast/spring/SessionCastProperties.java
+++ b/src/main/java/io/sessioncast/spring/SessionCastProperties.java
@@ -1,0 +1,70 @@
+package io.sessioncast.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@ConfigurationProperties(prefix = "sessioncast")
+public class SessionCastProperties {
+
+    private Relay relay = new Relay();
+    private Agent agent = new Agent();
+    private Reconnect reconnect = new Reconnect();
+    private Api api = new Api();
+
+    public Relay getRelay() { return relay; }
+    public void setRelay(Relay relay) { this.relay = relay; }
+    public Agent getAgent() { return agent; }
+    public void setAgent(Agent agent) { this.agent = agent; }
+    public Reconnect getReconnect() { return reconnect; }
+    public void setReconnect(Reconnect reconnect) { this.reconnect = reconnect; }
+    public Api getApi() { return api; }
+    public void setApi(Api api) { this.api = api; }
+
+    public static class Relay {
+        private String url;
+        private String token;
+        public String getUrl() { return url; }
+        public void setUrl(String url) { this.url = url; }
+        public String getToken() { return token; }
+        public void setToken(String token) { this.token = token; }
+    }
+
+    public static class Agent {
+        private String machineId;
+        private String label;
+        private boolean autoConnect;
+        public String getMachineId() { return machineId; }
+        public void setMachineId(String machineId) { this.machineId = machineId; }
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
+        public boolean isAutoConnect() { return autoConnect; }
+        public void setAutoConnect(boolean autoConnect) { this.autoConnect = autoConnect; }
+    }
+
+    public static class Reconnect {
+        private boolean enabled;
+        private Duration initialDelay = Duration.ofSeconds(2);
+        private Duration maxDelay = Duration.ofSeconds(60);
+        private int maxAttempts = 5;
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public Duration getInitialDelay() { return initialDelay; }
+        public void setInitialDelay(Duration initialDelay) { this.initialDelay = initialDelay; }
+        public Duration getMaxDelay() { return maxDelay; }
+        public void setMaxDelay(Duration maxDelay) { this.maxDelay = maxDelay; }
+        public int getMaxAttempts() { return maxAttempts; }
+        public void setMaxAttempts(int maxAttempts) { this.maxAttempts = maxAttempts; }
+    }
+
+    public static class Api {
+        private Duration timeout = Duration.ofSeconds(30);
+        private Duration llmTimeout = Duration.ofMinutes(5);
+        public Duration getTimeout() { return timeout; }
+        public void setTimeout(Duration timeout) { this.timeout = timeout; }
+        public Duration getLlmTimeout() { return llmTimeout; }
+        public void setLlmTimeout(Duration llmTimeout) { this.llmTimeout = llmTimeout; }
+    }
+}


### PR DESCRIPTION
## Summary
- `sessioncast-spring-boot-starter` 외부 SNAPSHOT 의존성을 제거하고 stub 클래스로 대체하여 별도 로컬 빌드 없이 바로 빌드 가능
- 컴포넌트 스캔 범위를 `io.sessioncast` 패키지로 확장하여 기동 오류 해결
- README에 빌드/실행 시 자주 발생하는 3가지 트러블슈팅 가이드 추가:
  - Java 버전 호환성 (`Unsupported class file major version`)
  - SessionCast 의존성 누락
  - WhaTap API 401 인증 오류

## Test plan
- [ ] `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew bootJar` 빌드 성공 확인
- [ ] `java -jar build/libs/autofix-agent-0.1.0-SNAPSHOT.jar` 기동 후 http://localhost:8095 접속 확인
- [ ] SessionCast 토큰 없이 규칙 기반 폴백 분석 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)